### PR TITLE
Expose ParseStrict to error on too many fields

### DIFF
--- a/cronexpr.go
+++ b/cronexpr.go
@@ -62,11 +62,22 @@ func MustParse(cronLine string) *Expression {
 /******************************************************************************/
 
 // Parse returns a new Expression pointer. An error is returned if a malformed
-// cron expression is supplied.
+// cron expression is supplied. ParseStrict does the same thing, but unlike
+// Parse, it will return an error if the provided cron line has too many
+// tokens.
 // See <https://github.com/gorhill/cronexpr#implementation> for documentation
 // about what is a well-formed cron expression from this library's point of
 // view.
+
 func Parse(cronLine string) (*Expression, error) {
+	return parse(cronLine, false)
+}
+
+func ParseStrict(cronLine string) (*Expression, error) {
+	return parse(cronLine, true)
+}
+
+func parse(cronLine string, strict bool) (*Expression, error) {
 
 	// Maybe one of the built-in aliases is being used
 	cron := cronNormalizer.Replace(cronLine)
@@ -76,8 +87,14 @@ func Parse(cronLine string) (*Expression, error) {
 	if fieldCount < 5 {
 		return nil, fmt.Errorf("missing field(s)")
 	}
-	// ignore fields beyond 7th
+
 	if fieldCount > 7 {
+		// In strict mode, error out
+		if strict {
+			return nil, fmt.Errorf("too many fields")
+		}
+
+		// In non-strict mode, ignore fields beyond 7th
 		fieldCount = 7
 	}
 

--- a/cronexpr/go.mod
+++ b/cronexpr/go.mod
@@ -1,0 +1,7 @@
+module github.com/gorhill/cronexpr/cronexpr
+
+go 1.14
+
+replace github.com/gorhill/cronexpr => ../
+
+require github.com/gorhill/cronexpr v0.0.0-00010101000000-000000000000

--- a/cronexpr/go.mod
+++ b/cronexpr/go.mod
@@ -1,7 +1,7 @@
-module github.com/gorhill/cronexpr/cronexpr
+module github.com/krallin/cronexpr/cronexpr
 
 go 1.14
 
-replace github.com/gorhill/cronexpr => ../
+replace github.com/krallin/cronexpr => ../
 
-require github.com/gorhill/cronexpr v0.0.0-00010101000000-000000000000
+require github.com/krallin/cronexpr v0.0.0-00010101000000-000000000000

--- a/cronexpr/go.sum
+++ b/cronexpr/go.sum
@@ -1,0 +1,2 @@
+github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 h1:f0n1xnMSmBLzVfsMMvriDyA75NB/oBgILX2GcHXIQzY=
+github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75/go.mod h1:g2644b03hfBX9Ov0ZBDgXXens4rxSxmqFBbhvKv2yVA=

--- a/cronexpr/go.sum
+++ b/cronexpr/go.sum
@@ -1,2 +1,0 @@
-github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75 h1:f0n1xnMSmBLzVfsMMvriDyA75NB/oBgILX2GcHXIQzY=
-github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75/go.mod h1:g2644b03hfBX9Ov0ZBDgXXens4rxSxmqFBbhvKv2yVA=

--- a/cronexpr/main.go
+++ b/cronexpr/main.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gorhill/cronexpr"
+	"github.com/krallin/cronexpr"
 )
 
 /******************************************************************************/

--- a/cronexpr_parse.go
+++ b/cronexpr_parse.go
@@ -438,6 +438,9 @@ func genericFieldParse(s string, desc fieldDescriptor) ([]*cronDirective, error)
 			directive.first = desc.atoi(snormal[pairs[2]:pairs[3]])
 			directive.last = desc.atoi(snormal[pairs[4]:pairs[5]])
 			directive.step = 1
+			if directive.last < directive.first {
+				return nil, fmt.Errorf("invalid interval %s (normalized to %d-%d)", snormal, directive.first, directive.last)
+			}
 			directives = append(directives, &directive)
 			continue
 		}

--- a/cronexpr_test.go
+++ b/cronexpr_test.go
@@ -305,6 +305,19 @@ func TestInterval_Interval60Issue(t *testing.T) {
 	}
 }
 
+// Issue: https://github.com/aptible/supercronic/issues/63
+func TestRange_OutOfOrder(t *testing.T) {
+	_, err := Parse("45 4 *  *  6-7")
+	if err == nil {
+		t.Errorf("parsing with range 6-7 should return err")
+	}
+
+	_, err = Parse("45 4 *  *  6-5")
+	if err == nil {
+		t.Errorf("parsing with range 6-5 should return err")
+	}
+}
+
 /******************************************************************************/
 
 func TestTooManyFields(t *testing.T) {

--- a/cronexpr_test.go
+++ b/cronexpr_test.go
@@ -307,6 +307,22 @@ func TestInterval_Interval60Issue(t *testing.T) {
 
 /******************************************************************************/
 
+func TestTooManyFields(t *testing.T) {
+	cronLine := "* * * * * * * foobar"
+
+	_, err := ParseStrict(cronLine)
+	if err == nil {
+		t.Errorf("ParseStrict with too many fields should return err ")
+	}
+
+	_, err = Parse(cronLine)
+	if err != nil {
+		t.Errorf("Parse with too many fields should not return err ")
+	}
+}
+
+/******************************************************************************/
+
 var benchmarkExpressions = []string{
 	"* * * * *",
 	"@hourly",

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gorhill/cronexpr
+
+go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/gorhill/cronexpr
+module github.com/krallin/cronexpr
 
 go 1.14


### PR DESCRIPTION
Parse currently ignores any tokens after the 7th, which means invalid
cron expressions might be allowed as long as invalid tokens are found
after the 7th character.

In some use cases (e.g. validating cron expressions provided by a user),
this might not be desirable. To allow for this use case, this adds a
ParseStrict function that returns an error if too many fields are
provided (it retains backwards compatibility by not touching Parse).

---

For some context, here's where I ran into this and could use a `ParseStrict` :smile: : https://github.com/aptible/supercronic/pull/34

Thanks!